### PR TITLE
Regression test for scan operation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ FIND_PACKAGE(Boost 1.66 COMPONENTS program_options date_time thread system local
 set(SMILE_LIB_OUTPUT_DIR "${CMAKE_BINARY_DIR}/lib")
 set(SMILE_BIN_OUTPUT_DIR "${CMAKE_BINARY_DIR}/bin")
 set(SMILE_TEST_OUTPUT_DIR "${SMILE_BIN_OUTPUT_DIR}/test")
+set(SMILE_REGTEST_OUTPUT_DIR "${SMILE_BIN_OUTPUT_DIR}/regtest")
 
 
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,3 +24,4 @@ SET(SMILE_LIBRARIES base storage memory tasking ${Boost_LIBRARIES})
 SET(SMILE_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src)
 
 add_subdirectory(tests)
+add_subdirectory(regtests)

--- a/src/regtests/CMakeLists.txt
+++ b/src/regtests/CMakeLists.txt
@@ -1,0 +1,27 @@
+include_directories(${GTEST_INCLUDE_DIRS})
+include_directories(${SMILE_INCLUDE_DIR})
+
+include_directories(${GTEST_INCLUDE_DIRS})
+
+function(create_regtest NAME)
+  add_executable(${NAME}
+    ${NAME}.cpp
+    )
+
+  target_link_libraries(${NAME} ${GTEST_LIBRARIES} ${SMILE_LIBRARIES} ) 
+  add_test(${NAME} ${SMILE_REGTEST_OUTPUT_DIR}/${NAME})
+
+  set_target_properties( ${NAME} 
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${SMILE_REGTEST_OUTPUT_DIR}
+    )
+endfunction(create_regtest)
+
+SET(TESTS "performance_regtest")
+
+foreach( TEST ${TESTS} )
+  create_regtest(${TEST})
+endforeach( TEST )
+
+add_custom_target(regtests COMMAND ${CMAKE_CTEST_COMMAND}
+  DEPENDS ${TESTS})

--- a/src/regtests/System.h
+++ b/src/regtests/System.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <sstream>
+#include <iostream>
+#include <functional>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <signal.h>
+
+struct System
+{
+    static void profile(const std::string& name,std::function<void()> body) {
+        std::string filename = name.find(".data") == std::string::npos ? (name + ".data") : name;
+
+        // Launch profiler
+        pid_t pid;
+        std::stringstream s;
+        s << getpid();
+        pid = fork();
+        if (pid == 0) {
+            auto fd=open("/dev/null",O_RDWR);
+            dup2(fd,1);
+            dup2(fd,2);
+            exit(execl("/usr/bin/perf","perf","record","-o",filename.c_str(),"-p",s.str().c_str(),nullptr));
+        }
+
+        // Run body
+        body();
+
+        // Kill profiler  
+        kill(pid,SIGINT);
+        waitpid(pid,nullptr,0);
+    }
+
+    static void profile(std::function<void()> body) {
+        profile("perf.data",body);
+    }
+};

--- a/src/regtests/performance_regtest.cpp
+++ b/src/regtests/performance_regtest.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+#include <memory/buffer_pool.h>
+#include "System.h"
+
+SMILE_NS_BEGIN
+
+/**
+ * Tests a scan operation of 4GB over a 1GB-size Buffer Pool for benchmarking purposes.
+ */
+TEST(PerformanceTest, PerformanceTestScan) {
+	uint32_t PAGE_SIZE = 64;
+	BufferPool bufferPool;
+	ASSERT_TRUE(bufferPool.create(BufferPoolConfig{1024*1024}, "./test.db", FileStorageConfig{PAGE_SIZE}, true) == ErrorCode::E_NO_ERROR);
+	BufferHandler bufferHandler;
+
+	std::vector<pageId_t> pages;
+
+	// Allocate 4GB in disk before proceed scanning.
+	System::profile("alloc", [&]() {
+		for (uint64_t i = 0; i < 4*1024*1024; i += PAGE_SIZE) {
+			ASSERT_TRUE(bufferPool.alloc(&bufferHandler) == ErrorCode::E_NO_ERROR);
+			ASSERT_TRUE(bufferPool.unpin(bufferHandler.m_pId) == ErrorCode::E_NO_ERROR);
+			pages.push_back(bufferHandler.m_pId);
+		}
+	});
+
+	// Scan operation
+	System::profile("scan", [&]() {
+		for (uint64_t i = 0; i < 4*1024*1024; i += PAGE_SIZE) {
+			ASSERT_TRUE(bufferPool.pin(pages[i/PAGE_SIZE], &bufferHandler) == ErrorCode::E_NO_ERROR);
+			ASSERT_TRUE(bufferPool.setPageDirty(bufferHandler.m_pId) == ErrorCode::E_NO_ERROR);
+			uint64_t dataToWrite = i;
+			memcpy(bufferHandler.m_buffer, &dataToWrite, sizeof(uint64_t));
+			ASSERT_TRUE(bufferPool.unpin(bufferHandler.m_pId) == ErrorCode::E_NO_ERROR);
+		}
+	});
+}
+
+SMILE_NS_END
+
+int main(int argc, char* argv[]){
+	::testing::InitGoogleTest(&argc,argv);
+	int ret = RUN_ALL_TESTS();
+	return ret;
+}


### PR DESCRIPTION
Added a test for testing the performance of a scan operation using our buffer pool. It makes use of an auxiliar library (_System.h_, more info at: https://muehe.org/posts/profiling-only-parts-of-your-code-with-perf/) which isolates the profiling done with perf.

- The test can be run with the command _make regtests_.
- If the test is run with perf, two files will be generated in _build_dir/src/regtests/_. On the one hand _alloc.data_ will contain perf info about the allocation part of the test. On the other hand, _scan.data_ will have perf info regarding the scan operation itself.
- perf info can be easily checked with the command: _perf report -i build_dir/src/regtests/scan.data_

