### PR TITLE
Graph Tests

### DIFF
--- a/src/regtests/CMakeLists.txt
+++ b/src/regtests/CMakeLists.txt
@@ -17,7 +17,7 @@ function(create_regtest NAME)
     )
 endfunction(create_regtest)
 
-SET(TESTS "alloc_regtest" "groupby_regtest" "hashjoin_regtest" "scan_regtest" "loadgraph_regtest")
+SET(TESTS "alloc_regtest" "groupby_regtest" "hashjoin_regtest" "scan_regtest" "loadgraph_regtest" "bfsgraph_regtest")
 
 foreach( TEST ${TESTS} )
   create_regtest(${TEST})

--- a/src/regtests/CMakeLists.txt
+++ b/src/regtests/CMakeLists.txt
@@ -17,7 +17,7 @@ function(create_regtest NAME)
     )
 endfunction(create_regtest)
 
-SET(TESTS "alloc_regtest" "groupby_regtest" "hashjoin_regtest" "scan_regtest")
+SET(TESTS "alloc_regtest" "groupby_regtest" "hashjoin_regtest" "scan_regtest" "loadgraph_regtest")
 
 foreach( TEST ${TESTS} )
   create_regtest(${TEST})

--- a/src/regtests/bfsgraph_regtest.cpp
+++ b/src/regtests/bfsgraph_regtest.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+#include <memory/buffer_pool.h>
+#include <tasking/tasking.h>
+
+SMILE_NS_BEGIN
+
+#define PAGE_SIZE_KB 64
+#define DATA_KB 4*1024*1024
+#define TOTAL_NUM_BFS 100
+
+/**
+ * Performs several BFS operations over a graph stored in a DB.
+ */
+TEST(PerformanceTest, PerformanceTestBFSGraph) {
+  	startThreadPool(1);
+  	BufferPool bufferPool;
+	ASSERT_TRUE(bufferPool.open(BufferPoolConfig{1024*1024}, "./graph.db") == ErrorCode::E_NO_ERROR);
+	BufferHandler metaDataHandler, handler;
+
+	// Load graph metadata
+	ASSERT_TRUE(bufferPool.pin(1, &metaDataHandler) == ErrorCode::E_NO_ERROR);
+	uint32_t* buffer = reinterpret_cast<uint32_t*>(metaDataHandler.m_buffer);
+	uint32_t numNodes = buffer[0];
+	uint32_t numEdges = buffer[1];
+	uint32_t firstNbrPage = buffer[2];
+	uint32_t NbrPage = buffer[3];
+	uint32_t firstEdgeNode = buffer[4];
+	uint32_t lastEdgeNode = buffer[5];
+	uint32_t elemsPerPage = (PAGE_SIZE_KB*1024)/sizeof(uint32_t);
+
+	for (uint32_t numBFS = 0; numBFS < TOTAL_NUM_BFS; ++numBFS) {
+		std::vector<bool> visited(numNodes, false);
+		std::queue<uint32_t> q;
+
+		// Generate random starting node
+		uint32_t currentNode = rand()%numNodes;
+		visited[currentNode] = true;
+		q.push(currentNode);
+
+		while (!q.empty()) {
+			currentNode = q.front();
+			q.pop();
+
+			// Obtain pointer to currentNode's neighbors
+			uint32_t firstNbrOffset = currentNode/elemsPerPage;
+			uint32_t firstNbrPosition = currentNode%elemsPerPage;
+			ASSERT_TRUE(bufferPool.pin(firstNbrPage + firstNbrOffset, &handler) == ErrorCode::E_NO_ERROR);
+			uint32_t* firstNbr = reinterpret_cast<uint32_t*>(handler.m_buffer);
+			uint32_t currentFirstNbr = firstNbr[firstNbrPosition];
+
+			// Discover how many neighbors the currentNode has
+			uint32_t numNeighbors;
+			if (currentFirstNbr == 0 && currentNode != firstEdgeNode) {
+				// firstNbr points to 0. If currentNode is different than the node containing the first edge, it means that
+				// currentNode has no neighbors
+				numNeighbors = 0;
+			}
+			else if (currentNode == lastEdgeNode) {
+				// Since currentNode is the last one, it will have as much neighbors as edges are left
+				numNeighbors = (numEdges-1) - currentFirstNbr;
+			}
+			else {
+				// currentNode will have as much neighbors as edges exist between its firstNbr and the firstNbr of the next
+				// node with edges
+				bool found = false;
+				uint32_t nextNode = currentNode + 1;
+				while (!found) {
+					uint32_t nextOffset = nextNode/elemsPerPage;
+					uint32_t nextPosition = nextNode%elemsPerPage;
+					BufferHandler nextHandler;
+					ASSERT_TRUE(bufferPool.pin(firstNbrPage + nextOffset, &nextHandler) == ErrorCode::E_NO_ERROR);
+					uint32_t* nextfirstNbr = reinterpret_cast<uint32_t*>(nextHandler.m_buffer);
+					if (nextfirstNbr[nextPosition] != 0) {
+						found = true;
+						numNeighbors = nextfirstNbr[nextPosition] - currentFirstNbr;
+					}
+					ASSERT_TRUE(bufferPool.unpin(nextHandler.m_pId) == ErrorCode::E_NO_ERROR);
+					++nextNode;
+				}
+			}
+
+			ASSERT_TRUE(bufferPool.unpin(handler.m_pId) == ErrorCode::E_NO_ERROR);
+
+			// Queue not visited neighbors
+			for (uint32_t i = 0; i < numNeighbors; ++i) {
+				uint32_t NbrOffset = currentFirstNbr/elemsPerPage;
+				uint32_t NbrPosition = currentFirstNbr%elemsPerPage;
+				ASSERT_TRUE(bufferPool.pin(NbrPage + NbrOffset, &handler) == ErrorCode::E_NO_ERROR);
+				uint32_t* Nbr = reinterpret_cast<uint32_t*>(handler.m_buffer);
+				uint32_t neighbor = Nbr[NbrPosition];
+
+				if (!visited[neighbor]) {
+					visited[neighbor] = true;
+					q.push(neighbor);
+				}
+
+				ASSERT_TRUE(bufferPool.unpin(handler.m_pId) == ErrorCode::E_NO_ERROR);
+				++currentFirstNbr;
+			}
+		}		
+	}
+
+	stopThreadPool();
+	ASSERT_TRUE(bufferPool.close() == ErrorCode::E_NO_ERROR);
+}
+
+SMILE_NS_END
+
+int main(int argc, char* argv[]){
+	::testing::InitGoogleTest(&argc,argv);
+	int ret = RUN_ALL_TESTS();
+	return ret;
+}

--- a/src/regtests/bfsgraph_regtest.cpp
+++ b/src/regtests/bfsgraph_regtest.cpp
@@ -12,96 +12,98 @@ SMILE_NS_BEGIN
  * Performs several BFS operations over a graph stored in a DB.
  */
 TEST(PerformanceTest, PerformanceTestBFSGraph) {
-  	startThreadPool(1);
-  	BufferPool bufferPool;
-	ASSERT_TRUE(bufferPool.open(BufferPoolConfig{1024*1024}, "./graph.db") == ErrorCode::E_NO_ERROR);
-	BufferHandler metaDataHandler, handler;
+	if (std::ifstream("./graph.db")) {
+	  	startThreadPool(1);
+	  	BufferPool bufferPool;
+		ASSERT_TRUE(bufferPool.open(BufferPoolConfig{1024*1024}, "./graph.db") == ErrorCode::E_NO_ERROR);
+		BufferHandler metaDataHandler, handler;
 
-	// Load graph metadata
-	ASSERT_TRUE(bufferPool.pin(1, &metaDataHandler) == ErrorCode::E_NO_ERROR);
-	uint32_t* buffer = reinterpret_cast<uint32_t*>(metaDataHandler.m_buffer);
-	uint32_t numNodes = buffer[0];
-	uint32_t numEdges = buffer[1];
-	uint32_t firstNbrPage = buffer[2];
-	uint32_t NbrPage = buffer[3];
-	uint32_t firstEdgeNode = buffer[4];
-	uint32_t lastEdgeNode = buffer[5];
-	uint32_t elemsPerPage = (PAGE_SIZE_KB*1024)/sizeof(uint32_t);
+		// Load graph metadata
+		ASSERT_TRUE(bufferPool.pin(1, &metaDataHandler) == ErrorCode::E_NO_ERROR);
+		uint32_t* buffer = reinterpret_cast<uint32_t*>(metaDataHandler.m_buffer);
+		uint32_t numNodes = buffer[0];
+		uint32_t numEdges = buffer[1];
+		uint32_t firstNbrPage = buffer[2];
+		uint32_t NbrPage = buffer[3];
+		uint32_t firstEdgeNode = buffer[4];
+		uint32_t lastEdgeNode = buffer[5];
+		uint32_t elemsPerPage = (PAGE_SIZE_KB*1024)/sizeof(uint32_t);
 
-	for (uint32_t numBFS = 0; numBFS < TOTAL_NUM_BFS; ++numBFS) {
-		std::vector<bool> visited(numNodes, false);
-		std::queue<uint32_t> q;
+		for (uint32_t numBFS = 0; numBFS < TOTAL_NUM_BFS; ++numBFS) {
+			std::vector<bool> visited(numNodes, false);
+			std::queue<uint32_t> q;
 
-		// Generate random starting node
-		uint32_t currentNode = rand()%numNodes;
-		visited[currentNode] = true;
-		q.push(currentNode);
+			// Generate random starting node
+			uint32_t currentNode = rand()%numNodes;
+			visited[currentNode] = true;
+			q.push(currentNode);
 
-		while (!q.empty()) {
-			currentNode = q.front();
-			q.pop();
+			while (!q.empty()) {
+				currentNode = q.front();
+				q.pop();
 
-			// Obtain pointer to currentNode's neighbors
-			uint32_t firstNbrOffset = currentNode/elemsPerPage;
-			uint32_t firstNbrPosition = currentNode%elemsPerPage;
-			ASSERT_TRUE(bufferPool.pin(firstNbrPage + firstNbrOffset, &handler) == ErrorCode::E_NO_ERROR);
-			uint32_t* firstNbr = reinterpret_cast<uint32_t*>(handler.m_buffer);
-			uint32_t currentFirstNbr = firstNbr[firstNbrPosition];
+				// Obtain pointer to currentNode's neighbors
+				uint32_t firstNbrOffset = currentNode/elemsPerPage;
+				uint32_t firstNbrPosition = currentNode%elemsPerPage;
+				ASSERT_TRUE(bufferPool.pin(firstNbrPage + firstNbrOffset, &handler) == ErrorCode::E_NO_ERROR);
+				uint32_t* firstNbr = reinterpret_cast<uint32_t*>(handler.m_buffer);
+				uint32_t currentFirstNbr = firstNbr[firstNbrPosition];
 
-			// Discover how many neighbors the currentNode has
-			uint32_t numNeighbors;
-			if (currentFirstNbr == 0 && currentNode != firstEdgeNode) {
-				// firstNbr points to 0. If currentNode is different than the node containing the first edge, it means that
-				// currentNode has no neighbors
-				numNeighbors = 0;
-			}
-			else if (currentNode == lastEdgeNode) {
-				// Since currentNode is the last one, it will have as much neighbors as edges are left
-				numNeighbors = (numEdges-1) - currentFirstNbr;
-			}
-			else {
-				// currentNode will have as much neighbors as edges exist between its firstNbr and the firstNbr of the next
-				// node with edges
-				bool found = false;
-				uint32_t nextNode = currentNode + 1;
-				while (!found) {
-					uint32_t nextOffset = nextNode/elemsPerPage;
-					uint32_t nextPosition = nextNode%elemsPerPage;
-					BufferHandler nextHandler;
-					ASSERT_TRUE(bufferPool.pin(firstNbrPage + nextOffset, &nextHandler) == ErrorCode::E_NO_ERROR);
-					uint32_t* nextfirstNbr = reinterpret_cast<uint32_t*>(nextHandler.m_buffer);
-					if (nextfirstNbr[nextPosition] != 0) {
-						found = true;
-						numNeighbors = nextfirstNbr[nextPosition] - currentFirstNbr;
-					}
-					ASSERT_TRUE(bufferPool.unpin(nextHandler.m_pId) == ErrorCode::E_NO_ERROR);
-					++nextNode;
+				// Discover how many neighbors the currentNode has
+				uint32_t numNeighbors;
+				if (currentFirstNbr == 0 && currentNode != firstEdgeNode) {
+					// firstNbr points to 0. If currentNode is different than the node containing the first edge, it means that
+					// currentNode has no neighbors
+					numNeighbors = 0;
 				}
-			}
-
-			ASSERT_TRUE(bufferPool.unpin(handler.m_pId) == ErrorCode::E_NO_ERROR);
-
-			// Queue not visited neighbors
-			for (uint32_t i = 0; i < numNeighbors; ++i) {
-				uint32_t NbrOffset = currentFirstNbr/elemsPerPage;
-				uint32_t NbrPosition = currentFirstNbr%elemsPerPage;
-				ASSERT_TRUE(bufferPool.pin(NbrPage + NbrOffset, &handler) == ErrorCode::E_NO_ERROR);
-				uint32_t* Nbr = reinterpret_cast<uint32_t*>(handler.m_buffer);
-				uint32_t neighbor = Nbr[NbrPosition];
-
-				if (!visited[neighbor]) {
-					visited[neighbor] = true;
-					q.push(neighbor);
+				else if (currentNode == lastEdgeNode) {
+					// Since currentNode is the last one, it will have as much neighbors as edges are left
+					numNeighbors = (numEdges-1) - currentFirstNbr;
+				}
+				else {
+					// currentNode will have as much neighbors as edges exist between its firstNbr and the firstNbr of the next
+					// node with edges
+					bool found = false;
+					uint32_t nextNode = currentNode + 1;
+					while (!found) {
+						uint32_t nextOffset = nextNode/elemsPerPage;
+						uint32_t nextPosition = nextNode%elemsPerPage;
+						BufferHandler nextHandler;
+						ASSERT_TRUE(bufferPool.pin(firstNbrPage + nextOffset, &nextHandler) == ErrorCode::E_NO_ERROR);
+						uint32_t* nextfirstNbr = reinterpret_cast<uint32_t*>(nextHandler.m_buffer);
+						if (nextfirstNbr[nextPosition] != 0) {
+							found = true;
+							numNeighbors = nextfirstNbr[nextPosition] - currentFirstNbr;
+						}
+						ASSERT_TRUE(bufferPool.unpin(nextHandler.m_pId) == ErrorCode::E_NO_ERROR);
+						++nextNode;
+					}
 				}
 
 				ASSERT_TRUE(bufferPool.unpin(handler.m_pId) == ErrorCode::E_NO_ERROR);
-				++currentFirstNbr;
-			}
-		}		
-	}
 
-	stopThreadPool();
-	ASSERT_TRUE(bufferPool.close() == ErrorCode::E_NO_ERROR);
+				// Queue not visited neighbors
+				for (uint32_t i = 0; i < numNeighbors; ++i) {
+					uint32_t NbrOffset = currentFirstNbr/elemsPerPage;
+					uint32_t NbrPosition = currentFirstNbr%elemsPerPage;
+					ASSERT_TRUE(bufferPool.pin(NbrPage + NbrOffset, &handler) == ErrorCode::E_NO_ERROR);
+					uint32_t* Nbr = reinterpret_cast<uint32_t*>(handler.m_buffer);
+					uint32_t neighbor = Nbr[NbrPosition];
+
+					if (!visited[neighbor]) {
+						visited[neighbor] = true;
+						q.push(neighbor);
+					}
+
+					ASSERT_TRUE(bufferPool.unpin(handler.m_pId) == ErrorCode::E_NO_ERROR);
+					++currentFirstNbr;
+				}
+			}		
+		}
+
+		stopThreadPool();
+		ASSERT_TRUE(bufferPool.close() == ErrorCode::E_NO_ERROR);
+	}
 }
 
 SMILE_NS_END

--- a/src/regtests/loadgraph_regtest.cpp
+++ b/src/regtests/loadgraph_regtest.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+#include <memory/buffer_pool.h>
+
+SMILE_NS_BEGIN
+
+#define PAGE_SIZE_KB 64
+#define DATA_KB 4*1024*1024
+#define PATH_TO_GRAPH_FILE ""
+
+/**
+ * Reads a graph from a file and stores it in a DB using a buffer pool.
+ * 
+ * Graph files must have the following structure:
+ * 
+ * 		number_of_nodes		number_of_edges
+ * 		node1				neighbor1_of_node1
+ * 		node1				neighbor2_of_node1
+ * 		node2				neighbor1_of_node2
+ * 		node3				neighbor1_of_node3
+ * 		node3				neighbor2_of_node3
+ * 		...
+ * 
+ * Graph is stored in the DB with the following structure:
+ * 
+ * 		Page:		Data:
+ * 		0			Metadata --> number of nodes, number of edges, firstNbr starting page (fnp), Nbr starting page (np)
+ * 		fnp - np	firstNbr structure
+ * 		np - ...	Nbr structure
+ * 		
+ */
+TEST(PerformanceTest, PerformanceTestLoadGraph) {
+	if (PATH_TO_GRAPH_FILE != "") {
+		// Graph data
+		uint32_t* firstNbr;
+		uint32_t* Nbr;
+		uint32_t numNodes = 0, numEdges = 0;
+
+		// Load data from file
+		std::ifstream graphFile;
+	  	graphFile.open(PATH_TO_GRAPH_FILE);
+	  	if (graphFile.is_open()) {
+		  	uint32_t  orig, dest, lastOrig;
+		  	graphFile >> numNodes;
+		  	graphFile >> numEdges;
+		  	firstNbr = new uint32_t[numNodes]();
+		  	Nbr = new uint32_t[numEdges]();
+
+			for (uint32_t i = 0; i < numEdges; ++i) {
+				graphFile >> orig;
+	  			graphFile >> dest;
+
+	  			if (orig != lastOrig || i == 0) {
+	  				firstNbr[orig] = i;
+	  			}
+	  			lastOrig = orig;
+
+	  			Nbr[i] = dest;
+			}
+		}
+	  	graphFile.close();
+
+	  	// Save graph into DB
+	  	BufferPool bufferPool;
+		ASSERT_TRUE(bufferPool.create(BufferPoolConfig{1024*1024}, "./graph.db", FileStorageConfig{PAGE_SIZE_KB}, true) == ErrorCode::E_NO_ERROR);
+		BufferHandler metaDataHandler, dataHandler;
+
+		// Save graph metadata
+		ASSERT_TRUE(bufferPool.alloc(&metaDataHandler) == ErrorCode::E_NO_ERROR);
+		ASSERT_TRUE(bufferPool.setPageDirty(metaDataHandler.m_pId) == ErrorCode::E_NO_ERROR);
+		uint32_t* buffer = reinterpret_cast<uint32_t*>(metaDataHandler.m_buffer);
+		*buffer = numNodes; ++buffer;
+		*buffer = numEdges; ++buffer;
+
+		// Save firstNbr
+		uint32_t elemsPerPage = (PAGE_SIZE_KB*1024)/sizeof(uint32_t);
+		int remainingBytes = numNodes*sizeof(uint32_t);
+		for (uint32_t i = 0; i < numNodes; i += elemsPerPage) {
+			ASSERT_TRUE(bufferPool.alloc(&dataHandler) == ErrorCode::E_NO_ERROR);
+			ASSERT_TRUE(bufferPool.setPageDirty(dataHandler.m_pId) == ErrorCode::E_NO_ERROR);
+			memcpy(dataHandler.m_buffer, &firstNbr[i], std::min(PAGE_SIZE_KB*1024, remainingBytes));
+			remainingBytes -= PAGE_SIZE_KB*1024;
+			ASSERT_TRUE(bufferPool.unpin(dataHandler.m_pId) == ErrorCode::E_NO_ERROR);
+			if (i == 0) {
+				*buffer = dataHandler.m_pId; ++buffer;
+			}
+		}
+
+		// Save Nbr
+		remainingBytes = numEdges*sizeof(uint32_t);
+		for (uint32_t i = 0; i < numEdges; i += elemsPerPage) {
+			ASSERT_TRUE(bufferPool.alloc(&dataHandler) == ErrorCode::E_NO_ERROR);
+			ASSERT_TRUE(bufferPool.setPageDirty(dataHandler.m_pId) == ErrorCode::E_NO_ERROR);
+			memcpy(dataHandler.m_buffer, &Nbr[i], std::min(PAGE_SIZE_KB*1024, remainingBytes));
+			remainingBytes -= PAGE_SIZE_KB*1024;
+			ASSERT_TRUE(bufferPool.unpin(dataHandler.m_pId) == ErrorCode::E_NO_ERROR);
+			if (i == 0) {
+				*buffer = dataHandler.m_pId;
+			}
+		}
+
+		ASSERT_TRUE(bufferPool.unpin(metaDataHandler.m_pId) == ErrorCode::E_NO_ERROR);
+		ASSERT_TRUE(bufferPool.close() == ErrorCode::E_NO_ERROR);
+	}
+}
+
+SMILE_NS_END
+
+int main(int argc, char* argv[]){
+	::testing::InitGoogleTest(&argc,argv);
+	int ret = RUN_ALL_TESTS();
+	return ret;
+}

--- a/src/regtests/loadgraph_regtest.cpp
+++ b/src/regtests/loadgraph_regtest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <memory/buffer_pool.h>
+#include <tasking/tasking.h>
 
 SMILE_NS_BEGIN
 
@@ -103,6 +104,112 @@ TEST(PerformanceTest, PerformanceTestLoadGraph) {
 
 		delete firstNbr;
 		delete Nbr;
+	}
+}
+
+/**
+ * Checks that a graph has correctly been persisted into a DB. The program loads the graph from a DB
+ * and tests its correctness by comparing it to the one defined in PATH_TO_GRAPH_FILE.
+ * 
+ * Graph files must have the following structure:
+ * 
+ * 		number_of_nodes		number_of_edges
+ * 		node1				neighbor1_of_node1
+ * 		node1				neighbor2_of_node1
+ * 		node2				neighbor1_of_node2
+ * 		node3				neighbor1_of_node3
+ * 		node3				neighbor2_of_node3
+ * 		...
+ * 
+ * Graph should be stored in the DB with the following structure:
+ * 
+ * 		Page:		Data:
+ * 		0			Metadata --> number of nodes, number of edges, firstNbr starting page (fnp), Nbr starting page (np)
+ * 		fnp - np	firstNbr structure
+ * 		np - ...	Nbr structure
+ * 		
+ */
+TEST(PerformanceTest, PerformanceTestCheckGraph) {
+	if (PATH_TO_GRAPH_FILE != "" || !std::ifstream("./graph.db")) {
+		uint32_t* fileFirstNbr;
+		uint32_t* fileNbr;
+		uint32_t fileNumNodes = 0, fileNumEdges = 0;
+
+		// Load graph from file
+		std::ifstream graphFile;
+	  	graphFile.open(PATH_TO_GRAPH_FILE);
+	  	if (graphFile.is_open()) {
+		  	uint32_t  orig, dest, lastOrig;
+		  	graphFile >> fileNumNodes;
+		  	graphFile >> fileNumEdges;
+		  	fileFirstNbr = new uint32_t[fileNumNodes]();
+		  	fileNbr = new uint32_t[fileNumEdges]();
+
+			for (uint32_t i = 0; i < fileNumEdges; ++i) {
+				graphFile >> orig;
+	  			graphFile >> dest;
+
+	  			if (orig != lastOrig || i == 0) {
+	  				fileFirstNbr[orig] = i;
+	  			}
+	  			lastOrig = orig;
+
+	  			fileNbr[i] = dest;
+			}
+		}
+	  	graphFile.close();
+
+	  	// Open DB containing the graph
+	  	startThreadPool(1);
+	  	BufferPool bufferPool;
+		ASSERT_TRUE(bufferPool.open(BufferPoolConfig{1024*1024}, "./graph.db") == ErrorCode::E_NO_ERROR);
+		BufferHandler bufferHandler;
+
+		// Check DB-graph metadata
+		ASSERT_TRUE(bufferPool.pin(1, &bufferHandler) == ErrorCode::E_NO_ERROR);
+		uint32_t* buffer = reinterpret_cast<uint32_t*>(bufferHandler.m_buffer);
+		ASSERT_TRUE(buffer[0] == fileNumNodes);
+		ASSERT_TRUE(buffer[1] == fileNumEdges);
+		uint32_t firstNbrPage = buffer[2];
+		uint32_t NbrPage = buffer[3];
+
+		// Load DB-graph data
+		uint32_t* dbFirstNbr = new uint32_t[fileNumNodes]();
+		uint32_t* dbNbr = new uint32_t[fileNumEdges]();
+
+		uint32_t elemsPerPage = (PAGE_SIZE_KB*1024)/sizeof(uint32_t);
+		int remainingBytes = fileNumNodes*sizeof(uint32_t);
+		for (uint32_t i = 0; i < fileNumNodes; i += elemsPerPage) {
+			ASSERT_TRUE(bufferPool.pin(firstNbrPage+(i/elemsPerPage), &bufferHandler) == ErrorCode::E_NO_ERROR);
+			memcpy(&dbFirstNbr[i], bufferHandler.m_buffer, std::min(PAGE_SIZE_KB*1024, remainingBytes));
+			remainingBytes -= PAGE_SIZE_KB*1024;
+			ASSERT_TRUE(bufferPool.unpin(bufferHandler.m_pId) == ErrorCode::E_NO_ERROR);
+		}
+
+		remainingBytes = fileNumEdges*sizeof(uint32_t);
+		for (uint32_t i = 0; i < fileNumEdges; i += elemsPerPage) {
+			ASSERT_TRUE(bufferPool.pin(NbrPage+(i/elemsPerPage), &bufferHandler) == ErrorCode::E_NO_ERROR);
+			memcpy(&dbNbr[i], bufferHandler.m_buffer, std::min(PAGE_SIZE_KB*1024, remainingBytes));
+			remainingBytes -= PAGE_SIZE_KB*1024;
+			ASSERT_TRUE(bufferPool.unpin(bufferHandler.m_pId) == ErrorCode::E_NO_ERROR);
+		}
+
+		// Check firstNbr and Nbr
+		for (uint32_t i = 0; i < fileNumNodes; ++i) {
+			ASSERT_TRUE(fileFirstNbr[i] == dbFirstNbr[i]);
+		}
+
+		for (uint32_t i = 0; i < fileNumEdges; ++i) {
+			ASSERT_TRUE(fileNbr[i] == dbNbr[i]);
+		}
+
+		stopThreadPool();
+		ASSERT_TRUE(bufferPool.close() == ErrorCode::E_NO_ERROR);
+
+		delete fileFirstNbr;
+		delete fileNbr;
+		delete dbFirstNbr;
+		delete dbNbr;
 	}
 }
 

--- a/src/regtests/loadgraph_regtest.cpp
+++ b/src/regtests/loadgraph_regtest.cpp
@@ -68,8 +68,8 @@ TEST(PerformanceTest, PerformanceTestLoadGraph) {
 		ASSERT_TRUE(bufferPool.alloc(&metaDataHandler) == ErrorCode::E_NO_ERROR);
 		ASSERT_TRUE(bufferPool.setPageDirty(metaDataHandler.m_pId) == ErrorCode::E_NO_ERROR);
 		uint32_t* buffer = reinterpret_cast<uint32_t*>(metaDataHandler.m_buffer);
-		*buffer = numNodes; ++buffer;
-		*buffer = numEdges; ++buffer;
+		buffer[0] = numNodes;
+		buffer[1] = numEdges;
 
 		// Save firstNbr
 		uint32_t elemsPerPage = (PAGE_SIZE_KB*1024)/sizeof(uint32_t);
@@ -81,7 +81,7 @@ TEST(PerformanceTest, PerformanceTestLoadGraph) {
 			remainingBytes -= PAGE_SIZE_KB*1024;
 			ASSERT_TRUE(bufferPool.unpin(dataHandler.m_pId) == ErrorCode::E_NO_ERROR);
 			if (i == 0) {
-				*buffer = dataHandler.m_pId; ++buffer;
+				buffer[2] = dataHandler.m_pId;
 			}
 		}
 
@@ -94,12 +94,15 @@ TEST(PerformanceTest, PerformanceTestLoadGraph) {
 			remainingBytes -= PAGE_SIZE_KB*1024;
 			ASSERT_TRUE(bufferPool.unpin(dataHandler.m_pId) == ErrorCode::E_NO_ERROR);
 			if (i == 0) {
-				*buffer = dataHandler.m_pId;
+				buffer[3] = dataHandler.m_pId;
 			}
 		}
 
 		ASSERT_TRUE(bufferPool.unpin(metaDataHandler.m_pId) == ErrorCode::E_NO_ERROR);
 		ASSERT_TRUE(bufferPool.close() == ErrorCode::E_NO_ERROR);
+
+		delete firstNbr;
+		delete Nbr;
 	}
 }
 

--- a/src/regtests/loadgraph_regtest.cpp
+++ b/src/regtests/loadgraph_regtest.cpp
@@ -34,7 +34,7 @@ TEST(PerformanceTest, PerformanceTestLoadGraph) {
 		// Graph data
 		uint32_t* firstNbr;
 		uint32_t* Nbr;
-		uint32_t numNodes = 0, numEdges = 0;
+		uint32_t numNodes = 0, numEdges = 0, firstEdgeNode, lastEdgeNode;
 
 		// Load data from file
 		std::ifstream graphFile;
@@ -49,6 +49,13 @@ TEST(PerformanceTest, PerformanceTestLoadGraph) {
 			for (uint32_t i = 0; i < numEdges; ++i) {
 				graphFile >> orig;
 	  			graphFile >> dest;
+
+	  			if (i == 0) {
+	  				firstEdgeNode = orig;
+	  			}
+	  			else if (i == numEdges-1) {
+	  				lastEdgeNode = orig;
+	  			}
 
 	  			if (orig != lastOrig || i == 0) {
 	  				firstNbr[orig] = i;
@@ -99,6 +106,9 @@ TEST(PerformanceTest, PerformanceTestLoadGraph) {
 			}
 		}
 
+		buffer[4] = firstEdgeNode;
+		buffer[5] = lastEdgeNode;
+
 		ASSERT_TRUE(bufferPool.unpin(metaDataHandler.m_pId) == ErrorCode::E_NO_ERROR);
 		ASSERT_TRUE(bufferPool.close() == ErrorCode::E_NO_ERROR);
 
@@ -133,7 +143,7 @@ TEST(PerformanceTest, PerformanceTestCheckGraph) {
 	if (PATH_TO_GRAPH_FILE != "" || !std::ifstream("./graph.db")) {
 		uint32_t* fileFirstNbr;
 		uint32_t* fileNbr;
-		uint32_t fileNumNodes = 0, fileNumEdges = 0;
+		uint32_t fileNumNodes = 0, fileNumEdges = 0, fileFirstEdgeNode, fileLastEdgeNode;
 
 		// Load graph from file
 		std::ifstream graphFile;
@@ -148,6 +158,13 @@ TEST(PerformanceTest, PerformanceTestCheckGraph) {
 			for (uint32_t i = 0; i < fileNumEdges; ++i) {
 				graphFile >> orig;
 	  			graphFile >> dest;
+
+	  			if (i == 0) {
+	  				fileFirstEdgeNode = orig;
+	  			}
+	  			else if (i == fileNumEdges-1) {
+	  				fileLastEdgeNode = orig;
+	  			}
 
 	  			if (orig != lastOrig || i == 0) {
 	  				fileFirstNbr[orig] = i;
@@ -172,6 +189,8 @@ TEST(PerformanceTest, PerformanceTestCheckGraph) {
 		ASSERT_TRUE(buffer[1] == fileNumEdges);
 		uint32_t firstNbrPage = buffer[2];
 		uint32_t NbrPage = buffer[3];
+		ASSERT_TRUE(buffer[4] == fileFirstEdgeNode);
+		ASSERT_TRUE(buffer[5] == fileLastEdgeNode);
 
 		// Load DB-graph data
 		uint32_t* dbFirstNbr = new uint32_t[fileNumNodes]();

--- a/src/regtests/loadgraph_regtest.cpp
+++ b/src/regtests/loadgraph_regtest.cpp
@@ -140,7 +140,7 @@ TEST(PerformanceTest, PerformanceTestLoadGraph) {
  * 		
  */
 TEST(PerformanceTest, PerformanceTestCheckGraph) {
-	if (PATH_TO_GRAPH_FILE != "" || !std::ifstream("./graph.db")) {
+	if (PATH_TO_GRAPH_FILE != "" && std::ifstream("./graph.db")) {
 		uint32_t* fileFirstNbr;
 		uint32_t* fileNbr;
 		uint32_t fileNumNodes = 0, fileNumEdges = 0, fileFirstEdgeNode, fileLastEdgeNode;


### PR DESCRIPTION
Two new regtests have been added:

- _loadgraph_: Contains two tests. The first one reads a graph from a _.txt_ file and stores it in a DB using CSR style. The second one checks the correctness from the persisted graph by loading it from the DB and comparing it with the one defined in the original _.txt_ file.

- _bfsgraph_: Performs several BFSs over a graph stored in a DB. It does not load the whole graph but only the pages needed during the BFS traversal.